### PR TITLE
fixed size mapping for canvases

### DIFF
--- a/ColorByNumber/CanvasCreator.java
+++ b/ColorByNumber/CanvasCreator.java
@@ -48,7 +48,7 @@ public class CanvasCreator extends JFrame implements MouseListener{
         //==========
         try{
             String[] sizeString=sizeField.getText().split(",");
-            int[] canvasSize=new int[]{Integer.valueOf(sizeString[0]), Integer.valueOf(sizeString[1])};
+            int[] canvasSize=new int[]{Integer.valueOf(sizeString[1]), Integer.valueOf(sizeString[0])};
             String name=nameField.getText();
             BlankCanvas canvas=new BlankCanvas(name, canvasSize);
             this.setVisible(false);


### PR DESCRIPTION
the given dimensions for a new canvas is now inversed, so it's now x, then y. When a grid layout is made it takes y before x.